### PR TITLE
annotate subcommand and bugfixes

### DIFF
--- a/preserve/__init__.py
+++ b/preserve/__init__.py
@@ -1,1 +1,1 @@
-version='2.0.0'
+version='2.1.0'

--- a/preserve/__main__.py
+++ b/preserve/__main__.py
@@ -3,6 +3,8 @@
 
 import argparse
 import sys
+
+from .annotate import annotate
 from .bagcheck import bagcheck
 from .bytecount import bytecount
 from .compare import compare
@@ -19,6 +21,7 @@ def main():
     parser = argparse.ArgumentParser(
         description='Digital preservation utilities.'
         )
+
     subparsers = parser.add_subparsers(
         title='subcommands', 
         description='valid subcommands',
@@ -26,13 +29,44 @@ def main():
         metavar='{bc,inv,comp,ver}', 
         dest='cmd'
         )
+
     parser.add_argument(
         '-v', '--version', 
         action='version', 
         help='Print version number and exit',
         version=version
         )
+
     subparsers.required = True
+
+
+    # parser for the "annotate" sub-command
+    annotate_parser = subparsers.add_parser(
+        'annotate', aliases=['ann'],
+        help='Fill in missing inventory info by examining the filesystem',
+        description='Supplements an inventory CSV by scanning disk for files.'
+        )
+
+    annotate_parser.add_argument(
+        '-i', '--inventory', 
+        help='Inventory CSV to annotate', 
+        action='store'
+        )
+
+    annotate_parser.add_argument(
+        '-o', '--output', 
+        help='Output file to write', 
+        action='store'
+        )
+        
+    annotate_parser.add_argument(
+        '-r', '--root', 
+        help='Filesystem location to examine', 
+        action='store'
+        )
+
+    annotate_parser.set_defaults(func=annotate)
+
 
     # parser for the "bagcheck" sub-command
     bagcheck_parser = subparsers.add_parser(
@@ -40,17 +74,21 @@ def main():
         help='Compare an inventory file against a bagit bag',
         description='Checks relpath & checksum against bag manifest.'
         )
+
     bagcheck_parser.add_argument(
         '-i', '--inventory', 
         help='Inventory CSV to compare', 
         action='store'
         )
+
     bagcheck_parser.add_argument(
         '-b', '--bag', 
         help='Path to BagIt bag', 
         action='store'
         )
+
     bagcheck_parser.set_defaults(func=bagcheck)
+
 
     # parser for the "bytecount" sub-command
     bc_parser = subparsers.add_parser(
@@ -58,20 +96,25 @@ def main():
         help='Count files and sizes in bytes',
         description='Count files by type and sum bytes.'
         )
+
     bc_parser.add_argument(
         'path', help='path to search', action='store'
         )
+
     bc_parser.add_argument(
         '-r', '--recursive', 
         help='Recurse through subdirectories', 
         action='store_true'
         )
+
     bc_parser.add_argument(
         '-H', '--human', 
         help='Human-readable size', 
         action='store_true'
         )
+
     bc_parser.set_defaults(func=bytecount)
+
 
     # parser for the "inventory" sub-command
     inv_parser = subparsers.add_parser(
@@ -79,29 +122,36 @@ def main():
         help='Create inventory of files with checksums',
         description='Create dirlisting with file metadata.'
         )
+
     inv_parser.add_argument('path', help='path to search', action='store')
+
     inv_parser.add_argument(
         '-b', '--batch', 
         help='the name of the batch', 
         required=True, 
         action='store'
         )
+
     inv_parser.add_argument(
         '-o', '--outfile', 
         help='path to (new) output file', 
         action='store'
         )
+
     inv_parser.add_argument(
         '-e', '--existing', 
         help='path to (existing) output file', 
         action='store'
         )
+
     inv_parser.add_argument(
         '-a', '--algorithms', 
         help='hash algorithms to run', 
         action='store'
         )
+
     inv_parser.set_defaults(func=inventory)
+
 
     # parser for the "compare" sub-command
     comp_parser = subparsers.add_parser(
@@ -109,17 +159,21 @@ def main():
         help='Compare two or more inventories',
         description='Compare contents of file inventories.'
         )
+
     comp_parser.add_argument(
         '-r', '--relpath', 
         help='compare by relative paths', 
         action='store_true'
         )
+
     comp_parser.add_argument('first', help='first file')
     comp_parser.add_argument(
         'other', nargs='+', 
         help='one or more files to compare'
         )
+
     comp_parser.set_defaults(func=compare)
+
 
     # parser for the "verify" sub-command
     ver_parser = subparsers.add_parser(
@@ -127,21 +181,25 @@ def main():
         help='Verify two sets of files',
         description='Verify checksums, relpaths, filenames.'
         )
+
     ver_parser.add_argument(
         '-c', '--checksums', 
         help='Verify files by checksum', 
         action='store_true'
         )
+
     ver_parser.add_argument(
         '-r', '--relpaths', 
         help='Verify files by relative path', 
         action='store_true'
         )
+
     ver_parser.add_argument(
         '-f', '--filenames', 
         help='Verify files by filename', 
         action='store_true'
         )
+
     ver_parser.add_argument('first', help='first file or path')
     ver_parser.add_argument('second', help='second file or path')
     ver_parser.set_defaults(func=verify)
@@ -151,6 +209,7 @@ def main():
     sys.stderr.write(header("preserve.py"))
     sys.stderr.write(subheader(args.func.__name__))
     result = args.func(args)
+
     if result:
         sys.stderr.write(result)
         sys.stderr.write('\n\n')

--- a/preserve/annotate.py
+++ b/preserve/annotate.py
@@ -8,14 +8,20 @@ from .asset import Asset
 ALGS = ['md5', 'sha1', 'sha256']
 
 FIELDNAMES = ['BATCH', 'PATH', 'DIRECTORY', 'RELPATH', 'FILENAME', 'EXTENSION', 
-              'BYTES', 'MTIME', 'MODDATE', 'MD5', 'SHA1', 'SHA256']
+              'BYTES', 'MTIME', 'MODDATE', 'MD5', 'SHA1', 'SHA256', 'storageprovider',
+              'storagepath']
 
 
 def read_csv(filepath):
     '''Read asset data from CSV file'''
+    result = []
     with open(filepath) as handle:
         reader = csv.DictReader(handle)
-        return [row for row in reader]
+        for row in reader:
+            row.setdefault('storagepath', '')
+            row.setdefault('storageprovider', '')
+            result.append(row)
+    return result
 
 
 def scan_filesystem(root):
@@ -27,38 +33,53 @@ def scan_filesystem(root):
     return result
 
 
+def examine_matching_file(filename, root, row, file_index):
+    '''Locate file match in the index and annotate the spreadsheet row'''
+    updated = row
+    for path in file_index.get(filename, []):
+        asset = Asset().from_filesystem(path, root, *ALGS)
+        for algorithm in ALGS:
+            storedhash = row[algorithm.upper()]
+            calculated = getattr(asset, algorithm)
+            if storedhash == '':
+                updated[algorithm.upper()] = calculated
+            elif calculated != storedhash:
+                break
+            else:
+                sys.stderr.write(f" => {storedhash} == {calculated}\n")
+                continue
+        sys.stderr.write(" => Match!\n")
+        updated['PATH'] = path
+        return updated
+    sys.stderr.write("No match!\n")
+    return row
+
+
 def annotate(args):
     '''Read CSV and scan filesystem to fill in blanks in the data'''
-
     sys.stderr.write(f"Running with the following arguments:\n")
     sys.stderr.write(f" - CSV to annotate:     {args.inventory}\n")
     sys.stderr.write(f" - Directory to search: {args.root}\n")
     sys.stderr.write(f" - Write results to:    {args.output}\n\n")
 
     spreadsheet = read_csv(args.inventory)
-    sys.stderr.write(f"Read {len(spreadsheet)} lines from CSV")
+    sys.stderr.write(f"Read {len(spreadsheet)} lines from CSV\n")
 
     file_index = scan_filesystem(args.root)
-    sys.stderr.write(f"Created index of {len(file_index)} filenames")
+    sys.stderr.write(f"Created index of {len(file_index)} filenames\n")
 
-    handle = open(args.output, 'w')
-    writer = csv.DictWriter(handle, fieldnames=FIELDNAMES, 
-                            extrasaction='ignore')
+    handle = open(args.output, 'w', 1)
+    writer = csv.DictWriter(handle, fieldnames=FIELDNAMES, extrasaction='ignore')
     writer.writeheader()
 
-    for row in spreadsheet:
+    for n, row in enumerate(spreadsheet, 1):
         filename = row['FILENAME']
-        if row['PATH'] is '':
-            sys.stderr.write(f"Searching for a local path to {filename} ... ")
-            if filename in file_index:
-                for path in file_index[filename]:
-                    a = Asset().from_filesystem(path, args.root, *ALGS)
-                    if a.md5 == row['MD5']:
-                        sys.stderr.write("Match!\n")
-                        sys.stderr.write(f" => {a.md5} == {row['MD5']}\n")
-                        row['PATH'] = path
-                        break
-                    else:
-                        sys.stderr.write("No match!\n")
-                        sys.stderr.write(f" => {a.md5} != {row['MD5']}\n")
-        writer.writerow(row)
+        if row['PATH'] != '' or row['storagepath'] != '':
+            sys.stderr.write(f"{n}. Skipping completed row for {filename}\n")
+            #writer.writerow(row)
+        else:
+            sys.stderr.write(f"{n}. Searching for a local path to {filename} ...\n")
+            annotated = examine_matching_file(filename, args.root, row, file_index)
+            writer.writerow(annotated)
+
+    handle.close()

--- a/preserve/annotate.py
+++ b/preserve/annotate.py
@@ -1,0 +1,59 @@
+import csv
+import os
+import sys
+
+from .manifest import Manifest
+from .asset import Asset
+
+ALGS = ['md5', 'sha1', 'sha256']
+FIELDNAMES = ['BATCH', 'PATH', 'DIRECTORY', 'RELPATH', 'FILENAME', 'EXTENSION', 
+              'BYTES', 'MTIME', 'MODDATE', 'MD5', 'SHA1', 'SHA256']
+
+
+def read_csv(filepath):
+    '''Read asset data from CSV file'''
+    with open(filepath) as handle:
+        reader = csv.DictReader(handle)
+        return [row for row in reader]
+
+
+def scan_filesystem(root):
+    '''Create lookup of filepaths by filname in asset directory'''
+    result = {}
+    for currentdir, subdirs, files in os.walk(root):
+        for file in files:
+            result.setdefault(file, []).append(os.path.join(currentdir, file))
+    return result
+
+
+def annotate(args):
+    '''Read CSV and scan filesystem to fill in blanks in the data'''
+
+    sys.stderr.write(f" => CSV to annotate: {args.inventory}\n")
+    sys.stderr.write(f" => Root to search:  {args.root}\n")
+    sys.stderr.write(f" => File to write:  {args.output}\n\n")
+
+    spreadsheet = read_csv(args.inventory)
+    file_index = scan_filesystem(args.root)
+
+    for row in spreadsheet:
+        filename = row['FILENAME']
+        if row['PATH'] is '':
+            sys.stderr.write(f"Searching for a local path to {filename} ... ")
+            if filename in file_index:
+                for path in file_index[filename]:
+                    a = Asset().from_filesystem(path, args.root, *ALGS)
+                    if a.md5 == row['MD5']:
+                        sys.stderr.write("Match!\n")
+                        sys.stderr.write(f" => {a.md5} == {row['MD5']}\n")
+                        row['PATH'] = path
+                        break
+                    else:
+                        sys.stderr.write("No match!\n")
+                        sys.stderr.write(f" => {a.md5} != {row['MD5']}\n")
+
+    with open(args.output, 'w') as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        for row in spreadsheet:
+            writer.writerow(row)

--- a/preserve/annotate.py
+++ b/preserve/annotate.py
@@ -6,6 +6,7 @@ from .manifest import Manifest
 from .asset import Asset
 
 ALGS = ['md5', 'sha1', 'sha256']
+
 FIELDNAMES = ['BATCH', 'PATH', 'DIRECTORY', 'RELPATH', 'FILENAME', 'EXTENSION', 
               'BYTES', 'MTIME', 'MODDATE', 'MD5', 'SHA1', 'SHA256']
 
@@ -29,12 +30,21 @@ def scan_filesystem(root):
 def annotate(args):
     '''Read CSV and scan filesystem to fill in blanks in the data'''
 
-    sys.stderr.write(f" => CSV to annotate: {args.inventory}\n")
-    sys.stderr.write(f" => Root to search:  {args.root}\n")
-    sys.stderr.write(f" => File to write:  {args.output}\n\n")
+    sys.stderr.write(f"Running with the following arguments:\n")
+    sys.stderr.write(f" - CSV to annotate:     {args.inventory}\n")
+    sys.stderr.write(f" - Directory to search: {args.root}\n")
+    sys.stderr.write(f" - Write results to:    {args.output}\n\n")
 
     spreadsheet = read_csv(args.inventory)
+    sys.stderr.write(f"Read {len(spreadsheet)} lines from CSV")
+
     file_index = scan_filesystem(args.root)
+    sys.stderr.write(f"Created index of {len(file_index)} filenames")
+
+    handle = open(args.output, 'w')
+    writer = csv.DictWriter(handle, fieldnames=FIELDNAMES, 
+                            extrasaction='ignore')
+    writer.writeheader()
 
     for row in spreadsheet:
         filename = row['FILENAME']
@@ -51,9 +61,4 @@ def annotate(args):
                     else:
                         sys.stderr.write("No match!\n")
                         sys.stderr.write(f" => {a.md5} != {row['MD5']}\n")
-
-    with open(args.output, 'w') as handle:
-        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
-        writer.writeheader()
-        for row in spreadsheet:
-            writer.writerow(row)
+        writer.writerow(row)

--- a/preserve/manifest.py
+++ b/preserve/manifest.py
@@ -19,7 +19,7 @@ class Manifest(list):
         elif os.path.isfile(self.path):
             self.source = "file"
             self.read_from_file()
-        self.root = os.path.commonpath([a.path for a in self]) + '/'
+            self.root = os.path.commonpath([a.path for a in self]) + '/'
         for asset in self:
             asset.relpath = re.sub(self.root, '', asset.path)
 

--- a/preserve/manifest.py
+++ b/preserve/manifest.py
@@ -15,6 +15,7 @@ class Manifest(list):
         self.path = path
         if os.path.isdir(self.path):
             self.source = "directory"
+            self.root = self.path
             self.read_from_dir()
         elif os.path.isfile(self.path):
             self.source = "file"


### PR DESCRIPTION
Adds the annotate subcommand which can be used to compare a batch CSV exported from patsy-db to a set of files on disk, supplementing the CSV with PATH information and supplying missing checksums based on examination of the files on disk. The annotations algorithms uses filename and md5 to match files to match files on disk to the information in the CSV, so the RELPATH does not need to be the same.

The resulting annotated CSV can be used as a transfer manifest for the aws-archiver transfer tool.

Additionally fixes a bug where the manifest read from disk did not have a root attribute.