### PR TITLE
LIBITD-2341: Changing versions to 1.1.0

### DIFF
--- a/preserve/__init__.py
+++ b/preserve/__init__.py
@@ -1,1 +1,1 @@
-version = '2.1.0'
+version = '1.1.0'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='preserve',
-    version='2.0.0',
+    version='1.1.0',
     description='Command-line digital preservation utilities.',
     author='Joshua A. Westgard',
     author_email="westgard@umd.edu",


### PR DESCRIPTION
At the digital collections tech team meeting it was determined to have preserve be versisoned at 1.1.0 instead of 2.0.0

https://umd-dit.atlassian.net/browse/LIBITD-2341