### PR TITLE
LIBITD 2357: Correcting storagelocations for HDD

### DIFF
--- a/preserve/__main__.py
+++ b/preserve/__main__.py
@@ -172,7 +172,14 @@ def main():
         help='The label for the drive',
         action='store',
         default=None
-    )
+        )
+
+    inv_parser.add_argument(
+        '-m', '--mount',
+        help='Path where the drive was mounted locally',
+        action='store',
+        default=None
+        )
 
     inv_parser.set_defaults(func=inventory)
 

--- a/preserve/annotate.py
+++ b/preserve/annotate.py
@@ -37,7 +37,7 @@ def examine_matching_file(filename, root, row, file_index):
     '''Locate file match in the index and annotate the spreadsheet row'''
     updated = row
     for path in file_index.get(filename, []):
-        asset = Asset().from_filesystem(path, root, label=None, *ALGS)
+        asset = Asset().from_filesystem(path, root, label=None, mount_path=None, *ALGS)
         for algorithm in ALGS:
             storedhash = row[algorithm.upper()]
             calculated = getattr(asset, algorithm)

--- a/preserve/annotate.py
+++ b/preserve/annotate.py
@@ -37,7 +37,7 @@ def examine_matching_file(filename, root, row, file_index):
     '''Locate file match in the index and annotate the spreadsheet row'''
     updated = row
     for path in file_index.get(filename, []):
-        asset = Asset().from_filesystem(path, root, *ALGS)
+        asset = Asset().from_filesystem(path, root, label=None, *ALGS)
         for algorithm in ALGS:
             storedhash = row[algorithm.upper()]
             calculated = getattr(asset, algorithm)

--- a/preserve/asset.py
+++ b/preserve/asset.py
@@ -129,7 +129,7 @@ class Asset():
                 'bytes':     os.path.getsize(path),
                 'extension': os.path.splitext(path)[1].lstrip('.').upper(),
                 }
-            
+
             values['moddate'] = dt.fromtimestamp(values['mtime']).strftime('%Y-%m-%dT%H:%M:%S')
             for algorithm, hash in calculate_hashes(path, args).items():
                 values[algorithm] = hash
@@ -137,7 +137,7 @@ class Asset():
                 values['etag'] = values['md5']
             else:
                 values['etag'] = calculate_etag(path, CHUNK_SIZE)
-            
+
             if label is not None:
                 values['storagelocation'] = f'{label}:{relpath}'
                 values['storageprovider'] = 'HDD'

--- a/preserve/asset.py
+++ b/preserve/asset.py
@@ -108,7 +108,7 @@ class Asset():
         return cls(**values)
 
     @classmethod
-    def from_filesystem(cls, path, base_path, label, *args):
+    def from_filesystem(cls, path, base_path, label, mount_path, *args):
         '''Alternate constructor for reading attributes from file'''
         if not os.path.isfile(path):
             raise TypeError
@@ -139,7 +139,7 @@ class Asset():
                 values['etag'] = calculate_etag(path, CHUNK_SIZE)
 
             if label is not None:
-                values['storagelocation'] = f'{label}:{relpath}'
+                values['storagelocation'] = f'{label}:{os.path.relpath(path, mount_path)}'
                 values['storageprovider'] = 'HDD'
 
         return cls(**values)

--- a/preserve/asset.py
+++ b/preserve/asset.py
@@ -128,16 +128,18 @@ class Asset():
                 'filename':  filename,
                 'bytes':     os.path.getsize(path),
                 'extension': os.path.splitext(path)[1].lstrip('.').upper(),
-                'storagelocation': f'{label}:{relpath}',
-                'storageprovider': 'HDD',
                 }
-            values['moddate'] = dt.fromtimestamp(values['mtime']).strftime(
-                                                           '%Y-%m-%dT%H:%M:%S')
+            
+            values['moddate'] = dt.fromtimestamp(values['mtime']).strftime('%Y-%m-%dT%H:%M:%S')
             for algorithm, hash in calculate_hashes(path, args).items():
                 values[algorithm] = hash
             if values['md5'] and (values['bytes'] <= CHUNK_SIZE):
                 values['etag'] = values['md5']
             else:
                 values['etag'] = calculate_etag(path, CHUNK_SIZE)
+            
+            if label is not None:
+                values['storagelocation'] = f'{label}:{relpath}'
+                values['storageprovider'] = 'HDD'
 
         return cls(**values)

--- a/preserve/bytecount.py
+++ b/preserve/bytecount.py
@@ -11,9 +11,9 @@ def bytecount(args):
        bytes and number of files broken down by extension.'''
     PATH = args.path
     print("Loading data from specified path...")
-    all_files = get_inventory(PATH)
+    all_files = get_inventory(PATH, label=None, mount=None)
     if not all_files:
-        sys.exit(
+        return(
             "ERROR: Could not read inventory data from the specified path.\n"
             )
 

--- a/preserve/bytecount.py
+++ b/preserve/bytecount.py
@@ -13,7 +13,7 @@ def bytecount(args):
     print("Loading data from specified path...")
     all_files = get_inventory(PATH, label=None, mount=None)
     if not all_files:
-        return(
+        return (
             "ERROR: Could not read inventory data from the specified path.\n"
             )
 

--- a/preserve/inventory.py
+++ b/preserve/inventory.py
@@ -17,8 +17,9 @@ def inventory(args):
        a specified path.'''
 
     FIELDNAMES = ['BATCH', 'PATH', 'DIRECTORY', 'RELPATH', 'FILENAME', 'EXTENSION',
-                  'BYTES', 'MTIME', 'MODDATE', 'MD5', 'ETAG', 'SHA1', 'SHA256', 'STORAGEPROVIDER', 'STORAGELOCATION'
-                  ]
+                  'BYTES', 'MTIME', 'MODDATE', 'MD5', 'ETAG', 'SHA1', 'SHA256',
+                  'STORAGEPROVIDER', 'STORAGELOCATION']
+
     BATCH = args.batch
 
     # Handle errors in the user-supplied paths
@@ -42,12 +43,6 @@ def inventory(args):
                 )
     else:
         OUTFILE = None
-
-    # Handle errors with label not provided
-    if args.label is None:
-        return (
-            "ERROR: Label was not provided"
-        )
 
     # Ensure that the path to be checked is valid
     if os.path.exists(args.path):

--- a/preserve/inventory.py
+++ b/preserve/inventory.py
@@ -51,6 +51,11 @@ def inventory(args):
         return (
             "ERROR: The specified search path does not exist.\n"
             )
+    
+    if (args.label is not None and args.mount is None) or (args.label is None and args.mount is not None):
+        return (
+            "ERROR: The label and mount flags must be provided together.\n"
+        )
 
     # Get a list of all files in the search path.
     all_files = list_files(PATH)
@@ -63,7 +68,7 @@ def inventory(args):
         sys.stderr.write("Writing to file: {0}\n".format(OUTFILE))
         # If the output file exists, read it and resume the job.
         if os.path.isfile(OUTFILE):
-            existing_entries = get_inventory(OUTFILE, args.label)
+            existing_entries = get_inventory(OUTFILE, args.label, args.mount)
             all_keys = set().union(
                 *(e.__dict__.keys() for e in existing_entries)
                 )
@@ -121,7 +126,7 @@ def inventory(args):
         algs_to_run = known_algs
     # Check each (remaining) file and generate metadata
     for f in files_to_check:
-        a = Asset().from_filesystem(f, PATH, args.label, *algs_to_run)
+        a = Asset().from_filesystem(f, PATH, args.label, args.mount, *algs_to_run)
         write_entry(writer, BATCH, a, FIELDNAMES)
 
         count += 1

--- a/preserve/inventory.py
+++ b/preserve/inventory.py
@@ -51,7 +51,7 @@ def inventory(args):
         return (
             "ERROR: The specified search path does not exist.\n"
             )
-    
+
     if (args.label is not None and args.mount is None) or (args.label is None and args.mount is not None):
         return (
             "ERROR: The label and mount flags must be provided together.\n"

--- a/preserve/manifest.py
+++ b/preserve/manifest.py
@@ -44,7 +44,7 @@ class Manifest(list):
     def read_from_dir(self):
         '''Read files on disk and populate manifest'''
         for f in list_files(self.path):
-            self.append(Asset().from_filesystem(f, self.root))
+            self.append(Asset().from_filesystem(f, self.root, label=None))
 
     def parse_tsm(self):
         '''Data parser function for reading data from Tivoli

--- a/preserve/manifest.py
+++ b/preserve/manifest.py
@@ -44,7 +44,7 @@ class Manifest(list):
     def read_from_dir(self):
         '''Read files on disk and populate manifest'''
         for f in list_files(self.path):
-            self.append(Asset().from_filesystem(f, self.root, label=None))
+            self.append(Asset().from_filesystem(f, self.root, label=None, mount_path=None))
 
     def parse_tsm(self):
         '''Data parser function for reading data from Tivoli

--- a/preserve/utils.py
+++ b/preserve/utils.py
@@ -64,7 +64,7 @@ def list_files(dir_path):
     return result
 
 
-def get_inventory(path, label):
+def get_inventory(path, label, mount):
     '''Given a path to a file or directory, return list of inventory metadata
        based on reading the inventory, or scanning the directory's files.'''
     if os.path.isfile(path):
@@ -83,7 +83,7 @@ def get_inventory(path, label):
         result = []
         for n, f in enumerate(list_files(path)):
             print("  => found {0} files.".format(n+1), end='\r')
-            a = Asset.from_filesystem(f, path, label)
+            a = Asset.from_filesystem(f, path, label, mount)
             result.append(a)
         print()
         return result

--- a/tests/preserve/asset_test.py
+++ b/tests/preserve/asset_test.py
@@ -6,5 +6,5 @@ def test_relpath_for_file_in_base_path_should_simply_be_filename(tmp_path):
     filename = 'relpath_test.txt'
     temp_file = create_temp_file(tmp_path, filename, "Test relpath")
 
-    asset = Asset.from_filesystem(temp_file, tmp_path, 'test label', *['md5', 'sha1', 'sha256'])
+    asset = Asset.from_filesystem(temp_file, tmp_path, None, None, *['md5', 'sha1', 'sha256'])
     assert filename == asset.relpath

--- a/tests/preserve/inventory_test.py
+++ b/tests/preserve/inventory_test.py
@@ -19,7 +19,7 @@ def test_inventory_stdout(capsys, tmp_path):
 
     temp_file = create_temp_file(temp_file_path, filename, "Test File1234")
     expected_rel_path = os.path.join(subdirectory, filename)
-    expected = generate_expected_values(temp_file, expected_rel_path)
+    expected = generate_expected_values(temp_file)
 
     batch = "TEST_BATCH"
     inventory_args = argparse.Namespace(batch=batch,
@@ -27,7 +27,8 @@ def test_inventory_stdout(capsys, tmp_path):
                                         existing=None,
                                         path=str(tmp_path),
                                         algorithms=None,
-                                        label='test')
+                                        label=None,
+                                        mount=None)
     inventory(inventory_args)
 
     captured = capsys.readouterr()
@@ -43,7 +44,7 @@ def test_inventory_stdout(capsys, tmp_path):
     assert stdout_lines[1] == expected_file_line
 
 
-def generate_expected_values(temp_file, relpath):
+def generate_expected_values(temp_file):
     '''
     Generates the expected values for the given file
     '''
@@ -62,8 +63,8 @@ def generate_expected_values(temp_file, relpath):
         "etag": hashes['md5'],
         "sha1":  hashes['sha1'],
         "sha256":  hashes['sha256'],
-        "storageprovider": 'HDD',
-        "storagelocation": f'test:{relpath}',
+        "storageprovider": '',
+        "storagelocation": '',
     }
 
     return expected_values


### PR DESCRIPTION
To correct the storage location for HDD's, we needed to remove the mount point from the absolute path of the files. To accomplish this, a new flag was created, the --mount path which is where the hard drive is mounted. The mount path will then be removed from the absolute path of the file.

Also, now the mount flag and label flag must be provided together is either is used, the program will catch this and error if only of them is provided without the other.

https://umd-dit.atlassian.net/browse/LIBITD-2357