### PR TITLE
LIBITD-2379: Fixing retrieving checksums and paths from tarfile

### DIFF
--- a/preserve/bagcheck.py
+++ b/preserve/bagcheck.py
@@ -16,11 +16,11 @@ def inspect(bag: str) -> set:
             return {tuple(line.strip().split(maxsplit=1)) for line in bag_manifest}
 
     elif tarfile.is_tarfile(bag):
-        directory_name = bag.split('/')[-1].split('.')[0]
-        tar = tarfile.open(bag, mode='r:*')
+        with tarfile.open(bag, mode='r:*') as tar:
+            top_directory = [directory for directory in tar.getnames() if '/' not in directory][0]
 
-        with tar.extractfile(f'{directory_name}/manifest-md5.txt') as bag_manifest:
-            return {tuple(line.strip().split(maxsplit=1)) for line in bag_manifest}
+            with tar.extractfile(f'{top_directory}/manifest-md5.txt') as bag_manifest:
+                return {tuple(line.decode().strip().split(maxsplit=1)) for line in bag_manifest}
 
     else:
         raise RuntimeError(f'{bag} is neither a directory or a tar file')


### PR DESCRIPTION
The tuples had byte formatted strings, so I had to call decode after extractfile call on the tarfile to have a proper str.
Also properly getting the top level directory of the tarball using getnames instead of the path of the tarball.

https://umd-dit.atlassian.net/browse/LIBITD-2379